### PR TITLE
Improve training performance on large datasets like MGnify

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,7 @@ training:
   num_workers: 12
   learn_rate: 0.001
   epochs: 100
+  batch_size: 1
   lr_schedule: true
   # mpnn_learn_rate: 0.001
   # two_stage: true

--- a/datasets.py
+++ b/datasets.py
@@ -17,7 +17,8 @@ from cache import cache
 ALPHABET = 'ACDEFGHIKLMNPQRSTVWY-'
 
 
-@cache(lambda cfg, pdb_file: pdb_file)
+# Caching seems to make things slower rather than faster!
+#@cache(lambda cfg, pdb_file: pdb_file)
 def parse_pdb_cached(cfg, pdb_file):
     return parse_PDB(pdb_file)
 
@@ -119,13 +120,19 @@ class MegaScaleDataset(torch.utils.data.Dataset):
 
         self.wt_names = self.split_wt_names[self.split]
 
-        for wt_name in tqdm(self.wt_names):
-            wt_rows = df.query('WT_name == @wt_name and mut_type == "wt"').reset_index(drop=True)
-            self.mut_rows[wt_name] = df.query('WT_name == @wt_name and mut_type != "wt"').reset_index(drop=True)
-            if type(cfg.reduce) is float and self.split == 'train':
-                self.mut_rows[wt_name] = self.mut_rows[wt_name].sample(frac=float(cfg.reduce), replace=False)
+        print("Loading data...")
+        mut_rows = df[(df.mut_type != "wt") & (df.WT_name.isin(self.wt_names))]
+        # Change in behavior:  we subsample ALL mutants rather than per grouping
+        # This also works better when there are few mutants per wildtype
+        if type(cfg.reduce) is float and self.split == 'train':
+            mut_rows = mut_rows.sample(frac=float(cfg.reduce), replace=False)
+        self.mut_rows = dict(iter(mut_rows.groupby('WT_name')))
 
-            self.wt_seqs[wt_name] = wt_rows.aa_seq[0]
+        # If we reduced the number of mutations, some WT won't be needed any more
+        self.wt_names = list(self.mut_rows.keys())
+        wt_rows = df[(df.mut_type == "wt") & (df.WT_name.isin(self.wt_names))]
+        self.wt_seqs = dict(zip(wt_rows.WT_name, wt_rows.aa_seq))
+        print("Done")
 
     def __len__(self):
         return len(self.wt_names)

--- a/protein_mpnn_utils.py
+++ b/protein_mpnn_utils.py
@@ -34,10 +34,12 @@ def _S_to_seq(S, mask):
     return seq
 
 
-def parse_PDB_biounits(x, atoms=['N', 'CA', 'C'], chain=None):
+def parse_PDB_biounits(lines, atoms=['N', 'CA', 'C'], chain=None):
     '''
-  input:  x = PDB filename
+  input:
           atoms = atoms to extract (optional)
+          lines = pre-read lines of the PDB file, which avoids re-parsing the
+                  same file once per candidate chain.
   output: (length, atoms, coords=(x,y,z)), sequence
   '''
 
@@ -65,41 +67,35 @@ def parse_PDB_biounits(x, atoms=['N', 'CA', 'C'], chain=None):
         return ["".join([aa_N_1.get(a, "-") for a in y]) for y in x]
 
     xyz, seq, min_resn, max_resn = {}, {}, 1e6, -1e6
-    for line in open(x, "rb"):
-        line = line.decode("utf-8", "ignore").rstrip()
+    for line in lines:
 
-        if line[:6] == "HETATM" and line[17:17 + 3] == "MSE":
-            line = line.replace("HETATM", "ATOM  ")
-            line = line.replace("MSE", "MET")
+        ch = line[21:22]
+        if ch == chain or chain is None:
+            atom = line[12:12 + 4].strip()
+            resi = line[17:17 + 3]
+            resn = line[22:22 + 5].strip()
+            x, y, z = [float(line[i:(i + 8)]) for i in [30, 38, 46]]
 
-        if line[:4] == "ATOM":
-            ch = line[21:22]
-            if ch == chain or chain is None:
-                atom = line[12:12 + 4].strip()
-                resi = line[17:17 + 3]
-                resn = line[22:22 + 5].strip()
-                x, y, z = [float(line[i:(i + 8)]) for i in [30, 38, 46]]
+            if resn[-1].isalpha():
+                resa, resn = resn[-1], int(resn[:-1]) - 1
+            else:
+                resa, resn = "", int(resn) - 1
+            #         resn = int(resn)
+            if resn < min_resn:
+                min_resn = resn
+            if resn > max_resn:
+                max_resn = resn
+            if resn not in xyz:
+                xyz[resn] = {}
+            if resa not in xyz[resn]:
+                xyz[resn][resa] = {}
+            if resn not in seq:
+                seq[resn] = {}
+            if resa not in seq[resn]:
+                seq[resn][resa] = resi
 
-                if resn[-1].isalpha():
-                    resa, resn = resn[-1], int(resn[:-1]) - 1
-                else:
-                    resa, resn = "", int(resn) - 1
-                #         resn = int(resn)
-                if resn < min_resn:
-                    min_resn = resn
-                if resn > max_resn:
-                    max_resn = resn
-                if resn not in xyz:
-                    xyz[resn] = {}
-                if resa not in xyz[resn]:
-                    xyz[resn][resa] = {}
-                if resn not in seq:
-                    seq[resn] = {}
-                if resa not in seq[resn]:
-                    seq[resn][resa] = resi
-
-                if atom not in xyz[resn][resa]:
-                    xyz[resn][resa][atom] = np.array([x, y, z])
+            if atom not in xyz[resn][resa]:
+                xyz[resn][resa][atom] = np.array([x, y, z])
 
     # convert to numpy arrays, fill in missing values
     seq_, xyz_ = [], []
@@ -126,14 +122,6 @@ def parse_PDB_biounits(x, atoms=['N', 'CA', 'C'], chain=None):
 def parse_PDB(path_to_pdb, input_chain_list=None, ca_only=False, side_chains=False):
     c = 0
     pdb_dict_list = []
-    init_alphabet = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
-                     'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
-                     'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z']
-    extra_alphabet = [str(item) for item in list(np.arange(300))]
-    chain_alphabet = init_alphabet + extra_alphabet
-
-    if input_chain_list:
-        chain_alphabet = input_chain_list
 
     biounit_names = [path_to_pdb]
     for biounit in biounit_names:
@@ -146,6 +134,23 @@ def parse_PDB(path_to_pdb, input_chain_list=None, ca_only=False, side_chains=Fal
         concat_O = []
         concat_mask = []
         coords_dict = {}
+
+        with open(biounit, 'rt') as f:
+            lines = []
+            for line in f:
+                if line[:6] == "HETATM" and line[17:17 + 3] == "MSE":
+                    line = line.replace("HETATM", "ATOM  ")
+                    line = line.replace("MSE", "MET")
+                if line[:4] == "ATOM":
+                    lines.append(line)
+
+        if input_chain_list:
+            chain_alphabet = input_chain_list
+        else:
+            # parse_PDB_biounits() gets called once for every letter in chain_alphabet(),
+            # so we want to only call it for chains that exist in our file
+            chain_alphabet = sorted(set(line[21:22] for line in lines))
+
         for letter in chain_alphabet:
             if ca_only:
                 sidechain_atoms = ['CA']
@@ -157,7 +162,7 @@ def parse_PDB(path_to_pdb, input_chain_list=None, ca_only=False, side_chains=Fal
                                    "NZ", "CZ", "CZ2", "CZ3", "CH2", "OH", "NH1", "NH2"]
             else:
                 sidechain_atoms = ['N', 'CA', 'C', 'O']
-            xyz, seq = parse_PDB_biounits(biounit, atoms=sidechain_atoms, chain=letter)
+            xyz, seq = parse_PDB_biounits(lines, atoms=sidechain_atoms, chain=letter)
             if type(xyz) != str:
                 concat_seq += seq[0]
                 my_dict['seq_chain_' + letter] = seq[0]

--- a/train_thermompnn.py
+++ b/train_thermompnn.py
@@ -49,32 +49,62 @@ class TransferModelPL(pl.LightningModule):
 
     def shared_eval(self, batch, batch_idx, prefix):
 
-        assert len(batch) == 1
-        mut_pdb, mutations = batch[0]
-        pred, _ = self(mut_pdb, mutations)
-
         ddg_mses = []
-        for mut, out in zip(mutations, pred):
-            if mut.ddG is not None:
-                ddg_mses.append(F.mse_loss(out["ddG"], mut.ddG))
-                for metric in self.metrics[f"{prefix}_metrics"]["ddG"].values():
-                    metric.update(out["ddG"], mut.ddG)
+        preds, targets = [], []
+        for mut_pdb, mutations in batch:
+            pred, _ = self(mut_pdb, mutations)
+            for mut, out in zip(mutations, pred):
+                if mut.ddG is not None:
+                    ddg_mses.append(F.mse_loss(out["ddG"], mut.ddG))
+                    preds.append(out["ddG"].reshape(-1))
+                    targets.append(mut.ddG.reshape(-1))
+
+        # Update each metric once per batch with concatenated tensors. Updating per-mutation
+        # makes SpearmanCorrCoef's list state grow by one tensor per mutation, which (combined
+        # with Lightning moving the live metric to device every step) causes an O(N^2) slowdown.
+        if preds:
+            batch_preds = torch.cat(preds)
+            batch_targets = torch.cat(targets)
+            for metric in self.metrics[f"{prefix}_metrics"]["ddG"].values():
+                metric.update(batch_preds, batch_targets)
+
+        # Per-step logging for debugging -- use with caution!
+        # if batch_idx % 10 == 0:
+        #     output = "ddG"
+        #     for name, metric in self.metrics[f"{prefix}_metrics"][output].items():
+        #         try:
+        #             value = metric.compute()
+        #         except ValueError:
+        #             continue
+        #         self.log(f"{prefix}_{output}_{name}", value, prog_bar=True, on_step=True, on_epoch=True)
 
         loss = 0.0 if len(ddg_mses) == 0 else torch.stack(ddg_mses).mean()
-        on_step = False
-        on_epoch = not on_step
-
-        output = "ddG"
-        for name, metric in self.metrics[f"{prefix}_metrics"][output].items():
-            try:
-                metric.compute()
-            except ValueError:
-                continue
-            self.log(f"{prefix}_{output}_{name}", metric, prog_bar=True, on_step=on_step, on_epoch=on_epoch,
-                        batch_size=len(batch))
         if loss == 0.0:
             return None
         return loss
+
+    def _log_epoch_metrics(self, prefix):
+        # Compute and log metrics once per epoch. Passing the live Metric object to self.log
+        # registers it in Lightning's result collection, which moves its (growing) state to the
+        # device on every step -- an O(N^2) cost. Logging plain scalars here avoids that.
+        output = "ddG"
+        for name, metric in self.metrics[f"{prefix}_metrics"][output].items():
+            try:
+                value = metric.compute()
+            except ValueError:
+                metric.reset()
+                continue
+            self.log(f"{prefix}_{output}_{name}", value, prog_bar=True, on_step=False, on_epoch=True)
+            metric.reset()
+
+    def on_train_epoch_end(self):
+        self._log_epoch_metrics('train')
+
+    def on_validation_epoch_end(self):
+        self._log_epoch_metrics('val')
+
+    def on_test_epoch_end(self):
+        self._log_epoch_metrics('test')
 
     def training_step(self, batch, batch_idx):
         return self.shared_eval(batch, batch_idx, 'train')
@@ -111,7 +141,8 @@ class TransferModelPL(pl.LightningModule):
         opt = torch.optim.AdamW(param_list, lr=self.learn_rate)
 
         if self.lr_schedule: # enable additional lr scheduler conditioned on val ddG mse
-            lr_sched = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer=opt, verbose=True, mode='min', factor=0.5)
+            # lr_sched = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer=opt, verbose=True, mode='min', factor=0.5)
+            lr_sched = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer=opt, mode='min', factor=0.5)
             return {
                 'optimizer': opt,
                 'lr_scheduler': lr_sched,
@@ -156,8 +187,10 @@ def train(cfg):
     else:
         train_workers, val_workers = 0, 0
 
-    train_loader = DataLoader(train_dataset, collate_fn=lambda x: x, shuffle=True, num_workers=train_workers)
-    val_loader = DataLoader(val_dataset, collate_fn=lambda x: x, num_workers=val_workers)
+    batch_size = cfg.training.batch_size if 'batch_size' in cfg.training else 1
+
+    train_loader = DataLoader(train_dataset, collate_fn=lambda x: x, shuffle=True, num_workers=train_workers, batch_size=batch_size)
+    val_loader = DataLoader(val_dataset, collate_fn=lambda x: x, num_workers=val_workers, batch_size=batch_size)
 
     model_pl = TransferModelPL(cfg)
     model_pl.stage = 1


### PR DESCRIPTION
Fixes #34 .

Addresses three bottlenecks that appear when training with datasets that have many wildtype domains, with a few mutations each:

1. Reading PDB models now access the disk only once, and does not make passes for chains that don't exist.
2. For Pandas operations in `MegaScaleDataset`, slow explicit loops have been replaced with fast vectorized operations.
3. Per-step metric logging has been converted to per-epoch, because Spearman CC slows down massively when the number of steps gets very large.

I've also added support for batches > 1.  The original code had one wildtype PDB per batch, with hundreds of mutations.  With datasets like MGnify where each wildtype has only a few mutations, this is insufficient to calculate meaningful gradients.  Larger batch sizes also reduce the number of steps per epoch, which diminishes the importance of the Spearman performance issue.